### PR TITLE
Changing Baseweb CSS include path in sample html

### DIFF
--- a/docs/getting-started/index.md
+++ b/docs/getting-started/index.md
@@ -58,7 +58,7 @@ Here is a typical starter template that has everything you'll need to get starte
     <title>BaseWeb</title>
 
     <!-- BaseWeb -->
-    <link rel="stylesheet" href="/assets/css/baseweb.min.css">
+    <link rel="stylesheet" href="/src/css/baseweb.min.css">
 
   </head>
   <body>


### PR DESCRIPTION
I changed the path from /assets/ to /src/ to match the current structure. On the demo / docs site: http://getbaseweb.com/getting-started/ you include a "Basic Template". I noticed the path in this doc would not match your new structure that does not include the /assets/ folder. 